### PR TITLE
feat: can now add games to lists

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-label": "^2.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,15 @@ importers:
 
   .:
     dependencies:
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.1.0)
       '@radix-ui/react-dialog':
         specifier: ^1.1.14
         version: 1.1.14(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -217,6 +226,28 @@ packages:
 
   '@clack/prompts@0.11.0':
     resolution: {integrity: sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw==}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@dprint/formatter@0.3.0':
     resolution: {integrity: sha512-N9fxCxbaBOrDkteSOzaCqwWjso5iAe+WJPsHC021JfHNj2ThInPNEF13ORDKta3llq5D1TlclODCvOvipH7bWQ==}
@@ -3376,6 +3407,31 @@ snapshots:
       '@clack/core': 0.5.0
       picocolors: 1.1.1
       sisteransi: 1.0.5
+
+  '@dnd-kit/accessibility@3.1.1(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.1.0)
+      '@dnd-kit/utilities': 3.2.2(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@dnd-kit/utilities': 3.2.2(react@19.1.0)
+      react: 19.1.0
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+      tslib: 2.8.1
 
   '@dprint/formatter@0.3.0': {}
 

--- a/src/app/dashboard/lists/[id]/add-game-dialog.tsx
+++ b/src/app/dashboard/lists/[id]/add-game-dialog.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { Plus } from "lucide-react";
+import { useState } from "react";
+
+import { Button } from "~/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "~/components/ui/dialog";
+import { Input } from "~/components/ui/input";
+import { Label } from "~/components/ui/label";
+import { InputTags } from "~/components/ui/tags-input";
+
+type AddGameDialogProps = {
+  listId: number;
+  addGameAction: (formData: FormData) => Promise<void>;
+};
+
+export function AddGameDialog({ listId, addGameAction }: AddGameDialogProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [tags, setTags] = useState<string[]>([]);
+
+  const handleAdd = async (formData: FormData) => {
+    formData.set("tags", tags.join(","));
+    await addGameAction(formData);
+    setIsOpen(false);
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+      <DialogTrigger asChild>
+        <Button>
+          <Plus className="mr-2 h-4 w-4" />
+          Add Game
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add New Game</DialogTitle>
+          <DialogDescription>
+            Add a new game to this list.
+          </DialogDescription>
+        </DialogHeader>
+        <form action={handleAdd}>
+          <input type="hidden" name="listId" value={listId} />
+          <div className="space-y-4">
+            <div className="grid gap-3">
+              <Label htmlFor="name">Name</Label>
+              <Input
+                id="name"
+                name="name"
+                placeholder="Game name"
+                required
+              />
+            </div>
+            <div className="grid gap-3">
+              <Label htmlFor="url">URL</Label>
+              <Input
+                id="url"
+                name="url"
+                type="url"
+                placeholder="https://example.com"
+              />
+            </div>
+            <div className="grid gap-3">
+              <Label htmlFor="siteName">Site Name</Label>
+              <Input
+                id="siteName"
+                name="siteName"
+                placeholder="Platform or site name"
+              />
+            </div>
+            <div className="grid gap-3">
+              <Label htmlFor="tags">Tags</Label>
+              <InputTags
+                id="tags"
+                name="tags"
+                value={tags}
+                onChange={setTags}
+                placeholder="e.g. tag1, tag2, tag3"
+              />
+            </div>
+          </div>
+          <DialogFooter className="mt-6">
+            <Button type="button" variant="outline" onClick={() => setIsOpen(false)}>
+              Cancel
+            </Button>
+            <Button type="submit">Add Game</Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/dashboard/lists/[id]/edit-game-dialog.tsx
+++ b/src/app/dashboard/lists/[id]/edit-game-dialog.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { Edit2 } from "lucide-react";
+import { useState } from "react";
+
+import { Button } from "~/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "~/components/ui/dialog";
+import { Input } from "~/components/ui/input";
+import { Label } from "~/components/ui/label";
+import { InputTags } from "~/components/ui/tags-input";
+
+import type { Game } from "./types";
+
+type EditGameDialogProps = {
+  game: Game;
+  updateGameAction: (formData: FormData) => Promise<void>;
+};
+
+export function EditGameDialog({ game, updateGameAction }: EditGameDialogProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [tags, setTags] = useState<string[]>(game.tags ? game.tags.split(",") : []);
+
+  const handleUpdate = async (formData: FormData) => {
+    formData.set("tags", tags.join(","));
+    await updateGameAction(formData);
+    setIsOpen(false);
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm">
+          <Edit2 className="h-4 w-4" />
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Edit Game</DialogTitle>
+          <DialogDescription>
+            Update the game details below.
+          </DialogDescription>
+        </DialogHeader>
+        <form action={handleUpdate}>
+          <input type="hidden" name="id" value={game.id} />
+          <input type="hidden" name="listId" value={game.listId || ""} />
+          <div className="space-y-4">
+            <div className="grid gap-3">
+              <Label htmlFor="name">Name</Label>
+              <Input
+                id="name"
+                name="name"
+                defaultValue={game.name}
+                placeholder="Game name"
+                required
+              />
+            </div>
+            <div className="grid gap-3">
+              <Label htmlFor="url">URL</Label>
+              <Input
+                id="url"
+                name="url"
+                type="url"
+                defaultValue={game.url || ""}
+                placeholder="https://example.com"
+              />
+            </div>
+            <div className="grid gap-3">
+              <Label htmlFor="siteName">Site Name</Label>
+              <Input
+                id="siteName"
+                name="siteName"
+                defaultValue={game.siteName || ""}
+                placeholder="Platform or site name"
+              />
+            </div>
+            <div className="grid gap-3">
+              <Label htmlFor="tags">Tags</Label>
+              <InputTags
+                id="tags"
+                name="tags"
+                value={tags}
+                onChange={setTags}
+                placeholder="e.g. tag1, tag2, tag3"
+              />
+            </div>
+          </div>
+          <DialogFooter className="mt-6">
+            <Button type="button" variant="outline" onClick={() => setIsOpen(false)}>
+              Cancel
+            </Button>
+            <Button type="submit">Save Changes</Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/dashboard/lists/[id]/game-list-detail.tsx
+++ b/src/app/dashboard/lists/[id]/game-list-detail.tsx
@@ -1,0 +1,274 @@
+"use client";
+
+import type { DragEndEvent } from "@dnd-kit/core";
+
+import {
+  closestCenter,
+  DndContext,
+
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { ExternalLink, GripVertical, Trash2 } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+
+import { Button } from "~/components/ui/button";
+
+import type { Game, GameList } from "./types";
+
+import { AddGameDialog } from "./add-game-dialog";
+import { EditGameDialog } from "./edit-game-dialog";
+
+type GameListDetailProps = {
+  gameList: GameList;
+  addGameAction: (formData: FormData) => Promise<void>;
+  updateGameAction: (formData: FormData) => Promise<void>;
+  deleteGameAction: (gameId: number, listId: number) => Promise<void>;
+  reorderGamesAction: (gameOrders: { id: number; orderIndex: number }[], listId: number) => Promise<void>;
+};
+
+function SortableGameItem({ game, updateGameAction, deleteGameAction }: {
+  game: Game;
+  updateGameAction: (formData: FormData) => Promise<void>;
+  deleteGameAction: (gameId: number, listId: number) => Promise<void>;
+}) {
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: game.id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  const handleDelete = async () => {
+    setIsDeleting(true);
+    try {
+      await deleteGameAction(game.id, game.listId!);
+    }
+    catch (error) {
+      console.error("Failed to delete game:", error);
+    }
+    finally {
+      setIsDeleting(false);
+    }
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={`
+        bg-card border-border group flex items-center gap-4 rounded-lg border
+        p-4 transition-shadow
+        hover:shadow-md
+      `}
+    >
+      <div
+        {...attributes}
+        {...listeners}
+        className={`
+          text-muted-foreground cursor-grab
+          active:cursor-grabbing
+        `}
+      >
+        <GripVertical className="h-4 w-4" />
+      </div>
+
+      <div className="flex-1">
+        <div className="flex items-start justify-between">
+          <div className="flex-1">
+            <div className="flex items-center gap-2">
+              <h3 className="font-semibold">{game.name}</h3>
+              {game.url && (
+                <a
+                  href={game.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={`
+                    text-muted-foreground transition-colors
+                    hover:text-primary
+                  `}
+                >
+                  <ExternalLink className="h-4 w-4" />
+                </a>
+              )}
+            </div>
+            <div className="group/siteinfo relative h-5 overflow-hidden">
+              <p
+                className={`
+                  text-muted-foreground text-sm transition-transform
+                  duration-300
+                  ${game.url ? "group-hover/siteinfo:-translate-y-6" : ""}
+                `}
+              >
+                {game.siteName}
+              </p>
+              {game.url && (
+                <p
+                  className={`
+                    text-muted-foreground absolute top-0 left-0 w-full
+                    translate-y-6 truncate text-sm transition-transform
+                    duration-300
+                    group-hover/siteinfo:translate-y-0
+                  `}
+                >
+                  {game.url}
+                </p>
+              )}
+            </div>
+            {game.tags && (
+              <div className="mt-2 flex flex-wrap gap-1">
+                {game.tags.split(",").map(tag => (
+                  <span
+                    key={`${game.id}-${tag.trim()}`}
+                    className={`
+                      bg-secondary text-secondary-foreground rounded px-2 py-1
+                      text-xs
+                    `}
+                  >
+                    {tag.trim()}
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+
+          <div className={`
+            flex gap-2 opacity-0 transition-opacity
+            group-hover:opacity-100
+          `}
+          >
+            <EditGameDialog game={game} updateGameAction={updateGameAction} />
+
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={handleDelete}
+              disabled={isDeleting}
+            >
+              <Trash2 className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function GameListDetail({
+  gameList,
+  addGameAction,
+  updateGameAction,
+  deleteGameAction,
+  reorderGamesAction,
+}: GameListDetailProps) {
+  const [games, setGames] = useState<Game[]>(gameList.games);
+  const prevGameListRef = useRef(gameList.games);
+
+  useEffect(() => {
+    if (prevGameListRef.current !== gameList.games) {
+      // disabling this rule here, it's a bit too strict. usually we want to protect against unconditional state updates
+      // eslint-disable-next-line react-hooks-extra/no-direct-set-state-in-use-effect
+      setGames(gameList.games);
+      prevGameListRef.current = gameList.games;
+    }
+  }, [gameList.games]);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
+
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event;
+
+    if (over && active.id !== over.id) {
+      const oldIndex = games.findIndex(game => game.id === active.id);
+      const newIndex = games.findIndex(game => game.id === over.id);
+
+      const newGames = arrayMove(games, oldIndex, newIndex);
+      setGames(newGames);
+
+      const gameOrders = newGames.map((game, index) => ({
+        id: game.id,
+        orderIndex: index + 1,
+      }));
+
+      reorderGamesAction(gameOrders, gameList.id);
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-xl font-semibold">
+            Games (
+            {games.length}
+            )
+          </h2>
+          <p className="text-muted-foreground text-sm">
+            Drag and drop to reorder games
+          </p>
+        </div>
+        <AddGameDialog listId={gameList.id} addGameAction={addGameAction} />
+      </div>
+
+      {games.length === 0
+        ? (
+            <div className={`
+              bg-card border-border rounded-lg border p-8 text-center
+            `}
+            >
+              <h3 className="mb-2 text-lg font-semibold">No games yet</h3>
+              <p className="text-muted-foreground mb-4">
+                Add your first game to get started organizing this list
+              </p>
+              <AddGameDialog listId={gameList.id} addGameAction={addGameAction} />
+            </div>
+          )
+        : (
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              onDragEnd={handleDragEnd}
+              id="game-list-dnd"
+            >
+              <SortableContext items={games} strategy={verticalListSortingStrategy}>
+                <div className="space-y-4">
+                  {games.map(game => (
+                    <SortableGameItem
+                      key={game.id}
+                      game={game}
+                      updateGameAction={updateGameAction}
+                      deleteGameAction={deleteGameAction}
+                    />
+                  ))}
+                </div>
+              </SortableContext>
+            </DndContext>
+          )}
+    </div>
+  );
+}

--- a/src/app/dashboard/lists/[id]/page.tsx
+++ b/src/app/dashboard/lists/[id]/page.tsx
@@ -1,0 +1,306 @@
+import { eq } from "drizzle-orm";
+import { ArrowLeft } from "lucide-react";
+import { revalidatePath } from "next/cache";
+import { headers } from "next/headers";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { Suspense } from "react";
+
+import type { gameList } from "~/lib/db/schema";
+
+import { Button } from "~/components/ui/button";
+import { auth } from "~/lib/auth";
+import { db } from "~/lib/db";
+import { game } from "~/lib/db/schema";
+
+import { GameListDetail } from "./game-list-detail";
+
+type Game = typeof game.$inferSelect;
+type GameList = typeof gameList.$inferSelect & {
+  games: Game[];
+};
+
+async function getGameList(id: number): Promise<GameList | null> {
+  "use server";
+
+  const session = await auth.api.getSession({
+    headers: await headers(),
+  });
+
+  if (!session) {
+    return null;
+  }
+
+  const list = await db.query.gameList.findFirst({
+    where: (gameList, { eq, and }) => and(
+      eq(gameList.id, id),
+      eq(gameList.userId, session.user.id),
+    ),
+    with: {
+      games: {
+        orderBy: (game, { asc }) => asc(game.orderIndex),
+      },
+    },
+  });
+
+  return list || null;
+}
+
+async function addGame(formData: FormData) {
+  "use server";
+
+  const rawData = {
+    listId: formData.get("listId") as string,
+    name: formData.get("name") as string,
+    url: formData.get("url") as string,
+    siteName: formData.get("siteName") as string,
+    tags: formData.get("tags") as string,
+  };
+
+  const listId = Number.parseInt(rawData.listId);
+  if (Number.isNaN(listId)) {
+    throw new TypeError("Invalid list ID");
+  }
+
+  const session = await auth.api.getSession({
+    headers: await headers(),
+  });
+
+  if (!session) {
+    throw new Error("You must be signed in to add games");
+  }
+
+  const existingList = await db.query.gameList.findFirst({
+    where: (gameList, { eq, and }) => and(
+      eq(gameList.id, listId),
+      eq(gameList.userId, session.user.id),
+    ),
+  });
+
+  if (!existingList) {
+    throw new Error("Game list not found or you don't have permission");
+  }
+
+  const maxOrderIndex = await db.query.game.findFirst({
+    where: (game, { eq }) => eq(game.listId, listId),
+    orderBy: (game, { desc }) => desc(game.orderIndex),
+  });
+
+  const orderIndex = (maxOrderIndex?.orderIndex || 0) + 1;
+
+  try {
+    await db.insert(game).values({
+      name: rawData.name,
+      url: rawData.url || null,
+      siteName: rawData.siteName || null,
+      tags: rawData.tags || null,
+      listId,
+      orderIndex,
+    });
+  }
+  catch (error) {
+    console.error("Error adding game:", error);
+    throw new Error("Failed to add game");
+  }
+
+  revalidatePath(`/dashboard/lists/${listId}`);
+}
+
+async function updateGame(formData: FormData) {
+  "use server";
+
+  const rawData = {
+    id: formData.get("id") as string,
+    listId: formData.get("listId") as string,
+    name: formData.get("name") as string,
+    url: formData.get("url") as string,
+    siteName: formData.get("siteName") as string,
+    tags: formData.get("tags") as string,
+  };
+
+  const gameId = Number.parseInt(rawData.id);
+  const listId = Number.parseInt(rawData.listId);
+
+  if (Number.isNaN(gameId) || Number.isNaN(listId)) {
+    throw new TypeError("Invalid game or list ID");
+  }
+
+  const session = await auth.api.getSession({
+    headers: await headers(),
+  });
+
+  if (!session) {
+    throw new Error("You must be signed in to update games");
+  }
+
+  const existingGame = await db.query.game.findFirst({
+    where: (game, { eq }) => eq(game.id, gameId),
+    with: {
+      gameList: true,
+    },
+  });
+
+  if (!existingGame || existingGame.gameList?.userId !== session.user.id) {
+    throw new Error("Game not found or you don't have permission");
+  }
+
+  try {
+    await db.update(game)
+      .set({
+        name: rawData.name,
+        url: rawData.url || null,
+        siteName: rawData.siteName || null,
+        tags: rawData.tags || null,
+        updatedAt: new Date(),
+      })
+      .where(eq(game.id, gameId));
+  }
+  catch (error) {
+    console.error("Error updating game:", error);
+    throw new Error("Failed to update game");
+  }
+
+  revalidatePath(`/dashboard/lists/${listId}`);
+}
+
+async function deleteGame(gameId: number, listId: number) {
+  "use server";
+
+  const session = await auth.api.getSession({
+    headers: await headers(),
+  });
+
+  if (!session) {
+    throw new Error("You must be signed in to delete games");
+  }
+
+  const existingGame = await db.query.game.findFirst({
+    where: (game, { eq }) => eq(game.id, gameId),
+    with: {
+      gameList: true,
+    },
+  });
+
+  if (!existingGame || existingGame.gameList?.userId !== session.user.id) {
+    throw new Error("Game not found or you don't have permission");
+  }
+
+  try {
+    await db.delete(game).where(eq(game.id, gameId));
+  }
+  catch (error) {
+    console.error("Error deleting game:", error);
+    throw new Error("Failed to delete game");
+  }
+
+  revalidatePath(`/dashboard/lists/${listId}`);
+}
+
+async function reorderGames(gameOrders: { id: number; orderIndex: number }[], listId: number) {
+  "use server";
+
+  const session = await auth.api.getSession({
+    headers: await headers(),
+  });
+
+  if (!session) {
+    throw new Error("You must be signed in to reorder games");
+  }
+
+  const existingList = await db.query.gameList.findFirst({
+    where: (gameList, { eq, and }) => and(
+      eq(gameList.id, listId),
+      eq(gameList.userId, session.user.id),
+    ),
+  });
+
+  if (!existingList) {
+    throw new Error("Game list not found or you don't have permission");
+  }
+
+  try {
+    for (const gameOrder of gameOrders) {
+      await db.update(game)
+        .set({ orderIndex: gameOrder.orderIndex })
+        .where(eq(game.id, gameOrder.id));
+    }
+  }
+  catch (error) {
+    console.error("Error reordering games:", error);
+    throw new Error("Failed to reorder games");
+  }
+
+  revalidatePath(`/dashboard/lists/${listId}`);
+}
+
+export default async function GameListDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const listId = Number.parseInt(id);
+
+  if (Number.isNaN(listId)) {
+    notFound();
+  }
+
+  const gameListData = await getGameList(listId);
+
+  if (!gameListData) {
+    notFound();
+  }
+
+  return (
+    <Suspense fallback={(
+      <div className="flex h-screen items-center justify-center">
+        <p>Loading...</p>
+      </div>
+    )}
+    >
+      <div className="bg-background text-primary p-6">
+        <div className="mx-auto max-w-4xl">
+          <Link
+            href="/dashboard/lists"
+            className="mb-4 inline-flex items-center"
+          >
+            <Button variant="ghost" size="sm">
+              <ArrowLeft className="mr-2 h-4 w-4" />
+              Back to Lists
+            </Button>
+          </Link>
+          <div className="mb-6 flex items-center gap-4">
+            <div>
+              <h1 className="text-3xl font-bold">{gameListData.name}</h1>
+              <p className="text-muted-foreground">
+                {gameListData.description || "No description provided"}
+              </p>
+              {gameListData.tags && (
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {gameListData.tags.split(",").map(tag => (
+                    <span
+                      key={tag.trim()}
+                      className={`
+                        bg-secondary text-secondary-foreground rounded-full px-3
+                        py-1 text-sm
+                      `}
+                    >
+                      {tag.trim()}
+                    </span>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+          <GameListDetail
+            gameList={gameListData}
+            addGameAction={addGame}
+            updateGameAction={updateGame}
+            deleteGameAction={deleteGame}
+            reorderGamesAction={reorderGames}
+          />
+        </div>
+      </div>
+    </Suspense>
+  );
+}

--- a/src/app/dashboard/lists/[id]/types.ts
+++ b/src/app/dashboard/lists/[id]/types.ts
@@ -1,0 +1,19 @@
+export type Game = {
+  id: number;
+  name: string;
+  url: string | null;
+  siteName: string | null;
+  tags: string | null;
+  orderIndex: number | null;
+  listId: number | null;
+  createdAt: Date | null;
+  updatedAt: Date | null;
+};
+
+export type GameList = {
+  id: number;
+  name: string;
+  description: string | null;
+  tags: string | null;
+  games: Game[];
+};

--- a/src/app/dashboard/lists/page.tsx
+++ b/src/app/dashboard/lists/page.tsx
@@ -1,6 +1,7 @@
 import { eq } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
 import { headers } from "next/headers";
+import Link from "next/link";
 
 import type { game } from "~/lib/db/schema";
 
@@ -117,8 +118,7 @@ export default async function DashboardListsPage() {
         <div
           className={`
             grid gap-6
-            md:grid-cols-2
-            lg:grid-cols-3
+            lg:grid-cols-2
           `}
         >
           {gameLists.map(list => (
@@ -214,8 +214,11 @@ function GameListCard({ list }: { list: GameList }) {
       <Button
         variant="outline"
         className="w-full text-sm"
+        asChild
       >
-        View List
+        <Link href={`/dashboard/lists/${list.id}`}>
+          View List
+        </Link>
       </Button>
       <span className="text-muted-foreground font-mono text-xs">
         {


### PR DESCRIPTION
lists can now have games added to them!

- users can now view their lists in the dashboard
- users can add / edit games
- users can drag to rearrange games

a couple more features before this is ready to rip:

- games should be able to be labelled as public or private
- ui feels a bit cluttered right now, both in the lists page and the game page
- would be cool if game site names were grabbed automatically when the url was entered